### PR TITLE
Additional check for isValid function added to escape AEM paths

### DIFF
--- a/src/lib/server/crawler/index.js
+++ b/src/lib/server/crawler/index.js
@@ -43,7 +43,7 @@ export async function initiateCrawler(domain) {
 				// Extract links from the current page and add them to the crawling queue if they match the pattern
 				await enqueueLinks({
 					globs: config.domainPattern,
-					exclude: ['*?*'],
+					exclude: ['*?*', '*/content/heliux/*'],
 					transformRequestFunction(req) {
 						return isValid(req, domain); // Passing domain as an argument
 					}

--- a/src/lib/server/crawler/isValid.js
+++ b/src/lib/server/crawler/isValid.js
@@ -1,9 +1,9 @@
 /**
  * Determines the validity of a request based on its URL.
- * The function checks if a request's URL contains any parameters and
- * whether it includes the given domain. If the URL contains parameters,
- * the function logs the ignored URL. Similarly, if the URL doesn't 
- * include the specified domain, the function logs that the page is 
+ * The function checks if a request's URL contains any parameters, whether it
+ * includes CMS paths and whether it includes the given domain.
+ * If the URL contains parameters, the function logs the ignored URL.
+ * Similarly, if the URL doesn't include the specified domain, the function logs that the page is
  * skipped. If neither of these conditions are met, the function
  * considers the request valid.
  *
@@ -12,17 +12,23 @@
  * @returns {boolean|Object} - Returns the request object if it's valid, otherwise returns false.
  */
 export function isValid(req, domain) {
-	// Ignore all links with parameters
-	if (req.url.includes('?')) {
-		console.log('Ignoring URL due to parameters: ' + req.url);
-		return false;
-	}
+    // Check if the URL includes the domain
+    if (!req.url.includes(domain)) {
+        console.log('Skipping the following page - not part of scanned domain: ' + req.url);
+        return false;
+    }
 
-	// Check if the URL includes the domain
-	if (!req.url.includes(domain)) {
-		console.log('Skipping the following page - not part of scanned domain: ' + req.url);
-		return false;
-	}
+    // Ignore all links with parameters
+    if (req.url.includes('?')) {
+        console.log('Ignoring URL due to parameters: ' + req.url);
+        return false;
+    }
 
-	return req;
+    // Ignore CMS paths
+    if (req.url.includes('/content/heliux')) {
+        console.log('Ignoring URL due to internal CMS path: ' + req.url);
+        return false;
+    }
+
+    return req;
 }


### PR DESCRIPTION
Bug WSDF-74 fixed by adding additional check to crawler's `isValid()` function